### PR TITLE
Rename the option processLines to transformLines

### DIFF
--- a/README.org
+++ b/README.org
@@ -80,6 +80,11 @@ Example:
   }
 #+end_src
 
+***** Deprecated: =processLines=
+=processLines= is a deprecated alias for =transformLines=.
+Using it will produce a warning at evaluation time.
+If both =transformLines= and =processLines= are provided, =transformLines= takes precedence and =processLines= is ignored.
+
 You can use the following predicates from this library:
 
 - tag :: Returns true if the headline matches a tag given as the argument. The argument must be a string.

--- a/README.org
+++ b/README.org
@@ -80,10 +80,7 @@ Example:
   }
 #+end_src
 
-***** Deprecated: =processLines=
-=processLines= is a deprecated alias for =transformLines=.
-Using it will produce a warning at evaluation time.
-If both =transformLines= and =processLines= are provided, =transformLines= takes precedence and =processLines= is ignored.
+/=processLines= has been renamed to =transformLines= and deprecated. They work exactly the same way./
 
 You can use the following predicates from this library:
 

--- a/README.org
+++ b/README.org
@@ -66,7 +66,7 @@ Example:
 
 Default: =[ "emacs-lisp" "elisp" ]=
 **** Filtering subtrees
-You can transform the input by specifying =processLines= option.
+You can transform the input by specifying =transformLines= option.
 It must be a function that takes a list of strings and returns a list of strings.
 
 This library also contains =excludeHeadlines= function which can be used to exclude subtrees according to a predicate on the headline text, so you can use it in the option.
@@ -76,7 +76,7 @@ Example:
 #+begin_src nix
   {
     # Exclude archived subtrees
-    processLines = excludeHeadlines (matchOrgTag "ARCHIVE");
+    transformLines = excludeHeadlines (matchOrgTag "ARCHIVE");
   }
 #+end_src
 

--- a/nix/tangleOrgBabel.nix
+++ b/nix/tangleOrgBabel.nix
@@ -4,12 +4,29 @@
     "emacs-lisp"
     "elisp"
   ],
-  processLines ? lines: lines,
+  transformLines ? null,
+  processLines ? null,
   tangleArg ? "yes",
 }:
 string:
 with builtins;
 let
+  warn =
+    msg: value:
+    if builtins ? warn then
+      builtins.warn msg value
+    else
+      trace msg value;
+
+  effectiveTransformLines =
+    if transformLines != null then
+      transformLines
+    else if processLines != null then
+      warn "`processLines` is deprecated; use `transformLines` instead."
+        processLines
+    else
+      lines: lines;
+
   lines = filter isString (split "\n" string);
 
   dropUntil = import ./dropUntil.nix;
@@ -56,4 +73,4 @@ let
       (go (acc ++ [ st2.before ]) st2.after);
 
 in
-concatStringsSep "\n" (concatLists (go [ ] (processLines lines)))
+concatStringsSep "\n" (concatLists (go [ ] (effectiveTransformLines lines)))

--- a/nix/tangleOrgBabel.nix
+++ b/nix/tangleOrgBabel.nix
@@ -1,7 +1,11 @@
 # Quick-and-dirty re-implementation of org-babel-tangle in Nix.
-{ languages ? [ "emacs-lisp" "elisp" ]
-, processLines ? lines: lines
-, tangleArg ? "yes"
+{
+  languages ? [
+    "emacs-lisp"
+    "elisp"
+  ],
+  processLines ? lines: lines,
+  tangleArg ? "yes",
 }:
 string:
 with builtins;
@@ -12,26 +16,23 @@ let
 
   blockStartRegexp =
     "[[:space:]]*\#\\+[Bb][Ee][Gg][Ii][Nn]_[Ss][Rr][Cc][[:space:]]+"
-    + "(" + (concatStringsSep "|" languages) + ")"
+    + "("
+    + (concatStringsSep "|" languages)
+    + ")"
     + "(([[:space:]].*)?)";
 
   parseParamsString = import ./parseParamsString.nix;
 
-  parseParamsString' = s:
-    if s == null
-    then { }
-    else parseParamsString s;
+  parseParamsString' = s: if s == null then { } else parseParamsString s;
 
-  checkBlockParams = attrs:
-    foldl' (acc: value: acc && value) true
-      (attrValues
-        (mapAttrs (name: value:
-          if name == ":tangle"
-          then value == tangleArg
-          else true
-        ) attrs));
+  checkBlockParams =
+    attrs:
+    foldl' (acc: value: acc && value) true (
+      attrValues (mapAttrs (name: value: if name == ":tangle" then value == tangleArg else true) attrs)
+    );
 
-  isBlockStart = line:
+  isBlockStart =
+    line:
     (match blockStartRegexp line != null)
     && checkBlockParams (parseParamsString' (elemAt (match blockStartRegexp line) 2));
 
@@ -41,16 +42,18 @@ let
 
   isBlockEnd = line: match blockEndRegexp line != null;
 
-  go = acc: xs:
+  go =
+    acc: xs:
     let
       st1 = dropUntil isBlockStart xs;
       st2 = splitListWith isBlockEnd st1;
     in
-    if length xs == 0
-    then acc
-    else if length st1 == 0
-    then acc
-    else (go (acc ++ [ st2.before ]) st2.after);
+    if length xs == 0 then
+      acc
+    else if length st1 == 0 then
+      acc
+    else
+      (go (acc ++ [ st2.before ]) st2.after);
 
 in
 concatStringsSep "\n" (concatLists (go [ ] (processLines lines)))

--- a/test/test.nix
+++ b/test/test.nix
@@ -55,4 +55,39 @@ pkgs.lib.runTests {
       "Extra spaces around params"
     ];
   };
+
+  testTangleOrgBabelTransformLines = {
+    expr = tangleOrgBabel {
+      transformLines = exclude (matchOrgTag "ARCHIVE");
+    } (readFile ./testTangle.org);
+
+    expected = ''
+      Default
+      Alternative language name
+      Upper case
+      :tangle yes
+      Extra spaces around params'';
+  };
+
+  testTangleOrgBabelProcessLinesDeprecated = {
+    expr = tangleOrgBabel {
+      processLines = exclude (matchOrgTag "ARCHIVE");
+    } (readFile ./testTangle.org);
+
+    expected = ''
+      Default
+      Alternative language name
+      Upper case
+      :tangle yes
+      Extra spaces around params'';
+  };
+
+  testTangleOrgBabelTransformLinesTakesPrecedence = {
+    expr = tangleOrgBabel {
+      transformLines = _: [ ];
+      processLines = _: [ "#+begin_src emacs-lisp" "deprecated" "#+end_src" ];
+    } (readFile ./testTangle.org);
+
+    expected = "";
+  };
 }

--- a/test/test.nix
+++ b/test/test.nix
@@ -61,12 +61,13 @@ pkgs.lib.runTests {
       transformLines = exclude (matchOrgTag "ARCHIVE");
     } (readFile ./testTangle.org);
 
-    expected = ''
+    expected = pkgs.lib.removeSuffix "\n" ''
       Default
       Alternative language name
       Upper case
       :tangle yes
-      Extra spaces around params'';
+      Extra spaces around params
+    '';
   };
 
   testTangleOrgBabelProcessLinesDeprecated = {
@@ -74,12 +75,13 @@ pkgs.lib.runTests {
       processLines = exclude (matchOrgTag "ARCHIVE");
     } (readFile ./testTangle.org);
 
-    expected = ''
+    expected = pkgs.lib.removeSuffix "\n" ''
       Default
       Alternative language name
       Upper case
       :tangle yes
-      Extra spaces around params'';
+      Extra spaces around params
+    '';
   };
 
   testTangleOrgBabelTransformLinesTakesPrecedence = {


### PR DESCRIPTION
The name processLines is too vague, and I’ve been meaning to rename it. This time, I will do so while preserving the existing API for backward compatibility.