### PR TITLE
fix: accept empty quoted header argument values

### DIFF
--- a/nix/parseParamsString.nix
+++ b/nix/parseParamsString.nix
@@ -39,7 +39,7 @@ let
     then head (match stripPat string)
     else string;
 
-  pat1 = "\"([^\"]+)\"(.*)";
+  pat1 = "\"([^\"]*)\"(.*)";
   
   pat2 = "([^\"][^[:space:]]*)(.*)";
 

--- a/test/testParams.nix
+++ b/test/testParams.nix
@@ -39,4 +39,11 @@ pkgs.lib.runTests {
     };
   };
 
+  testEmptyQuotedValue = {
+    expr = parse ":caption \"\"";
+    expected = {
+      ":caption" = "";
+    };
+  };
+
 }


### PR DESCRIPTION
pat1 required at least one character inside double quotes ([^\"]+ with +), causing header args like :caption "" to fall through to the throw "Match nothing" branch. Changing + to * allows zero-length quoted values.